### PR TITLE
Fix NgSpice shared FFI duplication

### DIFF
--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -360,6 +360,8 @@ class NgSpiceShared:
 
     ##############################################
 
+    already_read_ffi = False
+
     def _load_library(self):
 
         if ConfigInstall.OS.on_windows:
@@ -369,9 +371,11 @@ class NgSpiceShared:
             if 'SPICE_LIB_DIR' not in os.environ:
                 os.environ['SPICE_LIB_DIR'] = os.path.join(self.NGSPICE_PATH, 'share', 'ngspice')
 
-        api_path = os.path.join(os.path.dirname(__file__), 'api.h')
-        with open(api_path) as f:
-            ffi.cdef(f.read())
+        if not NgSpiceShared.already_read_ffi:
+            NgSpiceShared.already_read_ffi = True
+            api_path = os.path.join(os.path.dirname(__file__), 'api.h')
+            with open(api_path) as f:
+                ffi.cdef(f.read())
 
         if not self._ngspice_id:
             library_prefix = ''


### PR DESCRIPTION
When creating more than one `NgSpiceShared` instances, like in https://pyspice.fabrice-salvaire.fr/examples/ngspice-shared/external-source.html, for example to do two simulations in a row, there was an exception thrown from PySpice:
```
  File "/usr/local/lib/python3.6/dist-packages/PySpice/Spice/NgSpice/Shared.py", line 356, in __init__
    self._load_library()
  File "/usr/local/lib/python3.6/dist-packages/PySpice/Spice/NgSpice/Shared.py", line 374, in _load_library
    ffi.cdef(f.read())
  File "/usr/local/lib/python3.6/dist-packages/cffi/api.py", line 107, in cdef
    self._cdef(csource, override=override, packed=packed)
  File "/usr/local/lib/python3.6/dist-packages/cffi/api.py", line 121, in _cdef
    self._parser.parse(csource, override=override, **options)
  File "/usr/local/lib/python3.6/dist-packages/cffi/cparser.py", line 315, in parse
    self._internal_parse(csource)
  File "/usr/local/lib/python3.6/dist-packages/cffi/cparser.py", line 355, in _internal_parse
    decl.type, name=decl.name, partial_length_ok=True)
  File "/usr/local/lib/python3.6/dist-packages/cffi/cparser.py", line 587, in _get_type_and_quals
    tp = self._get_struct_union_enum_type('struct', type, name)
  File "/usr/local/lib/python3.6/dist-packages/cffi/cparser.py", line 734, in _get_struct_union_enum_type
    raise CDefError("duplicate declaration of struct %s" % name)
cffi.error.CDefError: <cdef source string>:7: duplicate declaration of struct ngcomplex
```

Tracing the source of the error showed that global `ffi` variable in PySpice was filled twice with API structures, which caused it to fail with duplicate declaration error. The simple fix in pull request is to just remember that API data was already read and not do it again.