### PR TITLE
Added 3-Terminal Element Class to specify Resistors and Capacitors with bulk node

### DIFF
--- a/PySpice/1.txt
+++ b/PySpice/1.txt
@@ -1,0 +1,15 @@
+total 52
+-rw-rw-r-- 1 nataraj nataraj    0 Feb  1 19:13 1.txt
+drwxrwxr-x 2 nataraj nataraj 4096 Feb  1 19:11 Config
+drwxrwxr-x 2 nataraj nataraj 4096 Feb  1 19:11 DeviceLibrary
+drwxrwxr-x 2 nataraj nataraj 4096 Feb  1 19:11 Doc
+-rw-rw-r-- 1 nataraj nataraj 1132 Feb  1 19:11 __init__.py
+drwxrwxr-x 2 nataraj nataraj 4096 Feb  1 19:11 Logging
+drwxrwxr-x 2 nataraj nataraj 4096 Feb  1 19:11 Math
+drwxrwxr-x 2 nataraj nataraj 4096 Feb  1 19:11 Physics
+drwxrwxr-x 2 nataraj nataraj 4096 Feb  1 19:11 Plot
+drwxrwxr-x 2 nataraj nataraj 4096 Feb  1 19:11 Probe
+drwxrwxr-x 2 nataraj nataraj 4096 Feb  1 19:11 Scripts
+drwxrwxr-x 5 nataraj nataraj 4096 Feb  1 19:11 Spice
+drwxrwxr-x 2 nataraj nataraj 4096 Feb  1 19:11 Tools
+drwxrwxr-x 2 nataraj nataraj 4096 Feb  1 19:11 Unit

--- a/PySpice/Spice/BasicElement.py
+++ b/PySpice/Spice/BasicElement.py
@@ -127,10 +127,15 @@ _module_logger = logging.getLogger(__name__)
 class DipoleElement(FixedPinElement):
     """This class implements a base class for dipole element."""
     PINS = ('plus', 'minus')
+    
+class ThreeTermElement(FixedPinElement):
+    """This class implements a base class for 3 terminal element."""
+    PINS = ('plus', 'minus', 'bulk')
 
 class TwoPortElement(FixedPinElement):
     """This class implements a base class for two-port element."""
     PINS = ('output_plus', 'output_minus', 'input_plus', 'input_minus')
+ 
 
 ####################################################################################################
 
@@ -366,6 +371,83 @@ class BehavioralResistor(DipoleElement):
     resistance_expression = ExpressionPositionalParameter(position=0, key_parameter=False)
     tc1 = FloatKeyParameter('tc1')
     tc2 = FloatKeyParameter('tc2')
+
+####################################################################################################
+
+
+class ThreeTermResistor(ThreeTermElement):
+
+    """This class implements a Semiconductor resistor.
+
+    Spice syntax:
+
+    .. code-block:: none
+
+        RXXXXXXX n+ n- bulk <value> <mname> <l=length> <w=width> <temp=val> <dtemp=val> m=<val> mult=<val> <ac=val> <scale=val> <noisy=0|1>
+
+    Keyword Parameters:
+
+      :attr:`model`
+
+      :attr:`length`
+         alias `l`
+
+      :attr:`width`
+         alias `w`
+
+      :attr:`temperature`
+         alias `temp`
+
+      :attr:`device_temperature`
+         alias `dtemp`
+
+      :attr:`multiplier`
+         alias `m`
+
+      :attr:`ac`
+
+      :attr:`scale`
+
+      :attr:`noisy`
+
+    Attributes:
+
+      :attr:`resistance`
+
+      :attr:`model`
+
+      :attr:`length`
+
+      :attr:`width`
+
+      :attr:`temperature`
+
+      :attr:`device_temperature`
+
+      :attr:`multiplier`
+
+      :attr:`ac`
+
+      :attr:`scale`
+
+      :attr:`noisy`
+
+    """
+
+    ALIAS = 'X'
+    PREFIX = 'X'
+
+    resistance = FloatPositionalParameter(position=0, key_parameter=False, unit=U_Ω)
+    model = ModelPositionalParameter(position=1, key_parameter=True)
+    length = FloatKeyParameter('l', unit=U_m)
+    width = FloatKeyParameter('w', unit=U_m)
+    temperature = FloatKeyParameter('temp', unit=U_Degree)
+    device_temperature = FloatKeyParameter('dtemp', unit=U_Degree)
+    multiplier = IntKeyParameter('m')
+    mult = IntKeyParameter('mult')
+    ac = FloatKeyParameter('ac', unit=U_Ω)
+    scale = FloatKeyParameter('scale')
+    noisy = BoolKeyParameter('noisy')
 
 ####################################################################################################
 


### PR DESCRIPTION
Edits in PySPice/Spice/BasicElement.py

Added 2 classes
1) ThreeTermElement
2) ThreeTermResistor

 Skywater 130nm PDK and several other commercial fabs offer 3 terminal resistors and capacitors. So I have added the above mentioned classes, I have specified 'X' as the prefix for the newly added resistor as the native spice netlist in 130nm PDK defines he resistors as an instance with prefix 'X' instead of 'R'. I have simulated a voltage divider after making this edit and it works fine.  I am yet to add 3 terminal capacitor class. But I will await your feedback on this before add that.

 Kindly review the code and let me know your feedback.

![PySpice_3T_Res](https://user-images.githubusercontent.com/95837240/152039762-0ca9dc92-6ba8-4ddf-b2d5-995cb4c270ce.png)


