### PR TITLE
handle ngspice notes and Trying in stderr

### DIFF
--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -625,7 +625,10 @@ class NgSpiceShared:
             self._stderr.append(content)
             if content.startswith('Warning:'):
                 func = self._logger.warning
-            # elif content.startswith('Warning:'):
+            elif content.startswith('Note:'):
+                func = self._logger.note
+            elif content.startswith('Trying'):
+                func = self._logger.note
             else:
                 self._error_in_stderr = True
                 func = self._logger.error


### PR DESCRIPTION
When parsing the ngspice stderr it could happen it throws only information messages like:
`Trying gmin =   1.6548E-12 Note: One successful gmin step`
or
`Note: Starting dynamic gmin stepping`
during an operating point analysis.
In my opinion they should be treated like warnings and not errors since the simulation sill goes to completion and gives the results after.
