### PR TITLE
Warn on note

### DIFF
--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -620,7 +620,8 @@ class NgSpiceShared:
             self._stderr.append(content)
             if content.startswith('Warning:'):
                 func = self._logger.warning
-            # elif content.startswith('Warning:'):
+            elif "Note:" in content:
+                func = self._logger.warning
             else:
                 self._error_in_stderr = True
                 func = self._logger.error

--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -618,7 +618,7 @@ class NgSpiceShared:
         prefix, _, content = message.partition(' ')
         if prefix == 'stderr':
             self._stderr.append(content)
-            if content.startswith('Warning:'):
+            if "Warning:" in content:
                 func = self._logger.warning
             elif "Note:" in content:
                 func = self._logger.warning


### PR DESCRIPTION
I'm using Ngspice version 36

During some simulations, I get messages like these on stderr:
Trying gmin =   1.0000E-05 Warning: Further gmin increment
and 
Trying gmin =   3.2781E-05 Note: One successful gmin step

Since neither starts with "Warning:" they are treated as errors, despite the simulation being successful.  These modifications allow the "Warning:" to be anywhere in the line to be treated as a warning, and also treats lines that include "Note:" in them as a warning.