### PR TITLE
Don't fail on convergence trial reporting

### DIFF
--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -623,6 +623,12 @@ class NgSpiceShared:
             # elif content.startswith('Warning:'):
             else:
                 self._error_in_stderr = True
+                # Non-standard convergence trials are reported to stderr
+                # but can complete successfully
+                completed = ("completed" in content) or ("finished" in content)
+                if content.startswith("Note:") and completed:
+                    self._error_in_stderr = False
+
                 func = self._logger.error
                 if content.strip() == "Note: can't find init file.":
                     self._spinit_not_found = True


### PR DESCRIPTION
When ngspice tries an alternative DC converge algorithm it reports the
progress on stderr. This patch makes PySpice not error out when the
alternative DC convergence has been reported to be successful.

Example of report on stderr from spice that previously raised an exception:
```
Note: Starting dynamic gmin stepping
Trying gmin =   1.0000E-03 Note: One successful gmin step
Trying gmin =   1.0000E-04 Note: One successful gmin step
Trying gmin =   1.0000E-05 Note: One successful gmin step
Trying gmin =   1.0000E-06 Note: One successful gmin step
Trying gmin =   1.0000E-07 Note: One successful gmin step
Trying gmin =   1.0000E-08 Note: One successful gmin step
Trying gmin =   1.0000E-09 Note: One successful gmin step
Trying gmin =   1.0000E-10 Note: One successful gmin step
Trying gmin =   1.0000E-11 Note: One successful gmin step
Trying gmin =   1.0000E-12 Note: One successful gmin step
Trying gmin =   1.0000E-12 Note: One successful gmin step
Note: Dynamic gmin stepping completed
```
I also saw source stepping that ended with `Note: ... finished successfully`