### PR TITLE
Include .measure results in Analysis with ngspice-shared

### DIFF
--- a/PySpice/Probe/WaveForm.py
+++ b/PySpice/Probe/WaveForm.py
@@ -254,7 +254,7 @@ class Analysis:
         self._branches = {waveform.name:waveform for waveform in branches}
         self._elements = {waveform.name:waveform for waveform in elements}
         self._internal_parameters = {waveform.name:waveform for waveform in internal_parameters}
-        self._measurements = measurements
+        self.measurements = measurements
 
     ##############################################
 
@@ -278,10 +278,6 @@ class Analysis:
     @property
     def internal_parameters(self):
         return self._internal_parameters
-    
-    @property
-    def measurements(self):
-        return self._measurements
 
    ##############################################
 
@@ -296,8 +292,8 @@ class Analysis:
             return self._elements[name]
         elif name in self._internal_parameters:
             return self._internal_parameters[name]
-        elif name in self._measurements:
-            return self._measurements[name]
+        elif name in self.measurements:
+            return self.measurements[name]
         else:
             raise IndexError(name)
 
@@ -328,7 +324,7 @@ class Analysis:
                 'Branches :' + os.linesep + self._format_dict(self._branches) + os.linesep +
                 'Elements :' + os.linesep + self._format_dict(self._elements) + os.linesep +
                 'Internal Parameters :' + os.linesep + self._format_dict(self._internal_parameters) +
-                'Measurements :' + os.linesep + self._format_dict(self._measurements)
+                'Measurements :' + os.linesep + self._format_dict(self.measurements)
             )
 
 ####################################################################################################

--- a/PySpice/Probe/WaveForm.py
+++ b/PySpice/Probe/WaveForm.py
@@ -244,7 +244,7 @@ class Analysis:
 
     ##############################################
 
-    def __init__(self, simulation, nodes=(), branches=(), elements=(), internal_parameters=()):
+    def __init__(self, simulation, nodes=(), branches=(), elements=(), internal_parameters=(), measurements={}):
 
         # Fixme: branches are elements in fact, and elements is not yet supported ...
 
@@ -254,6 +254,7 @@ class Analysis:
         self._branches = {waveform.name:waveform for waveform in branches}
         self._elements = {waveform.name:waveform for waveform in elements}
         self._internal_parameters = {waveform.name:waveform for waveform in internal_parameters}
+        self._measurements = measurements
 
     ##############################################
 
@@ -277,6 +278,10 @@ class Analysis:
     @property
     def internal_parameters(self):
         return self._internal_parameters
+    
+    @property
+    def measurements(self):
+        return self._measurements
 
    ##############################################
 
@@ -291,6 +296,8 @@ class Analysis:
             return self._elements[name]
         elif name in self._internal_parameters:
             return self._internal_parameters[name]
+        elif name in self._measurements:
+            return self._measurements[name]
         else:
             raise IndexError(name)
 
@@ -320,7 +327,8 @@ class Analysis:
                 'Nodes :' + os.linesep + self._format_dict(self._nodes) + os.linesep +
                 'Branches :' + os.linesep + self._format_dict(self._branches) + os.linesep +
                 'Elements :' + os.linesep + self._format_dict(self._elements) + os.linesep +
-                'Internal Parameters :' + os.linesep + self._format_dict(self._internal_parameters)
+                'Internal Parameters :' + os.linesep + self._format_dict(self._internal_parameters) +
+                'Measurements :' + os.linesep + self._format_dict(self._measurements)
             )
 
 ####################################################################################################

--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -1198,12 +1198,14 @@ class NgSpiceShared:
 
         # Parse out measurement results
         results = results if isinstance(results, list) else results.splitlines()
+        meas_start_index = 0
+        meas_end_index = 0
         for line in results:
             if line.startswith('Measurements'):
                 meas_start_index = results.index(line) + 1
             elif meas_start_index and '=' in line:
                 meas_end_index = results.index(line)
-        if meas_end_index:
+        if meas_start_index and meas_end_index:
             for line in results[meas_start_index:meas_end_index]:
                 # Extract each measurement result as a k,v pair
                 print(line)

--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -1189,12 +1189,24 @@ class NgSpiceShared:
         #  in the background thread and wait until the simulation is done
 
         command = 'bg_run' if background else 'run'
-        self.exec_command(command)
+        results = self.exec_command(command)
 
         if background:
             self._is_running = True
         else:
             self._logger.debug("Simulation is done")
+
+        # Parse out measurement results
+        results = results if isinstance(results, list) else results.splitlines()
+        for line in results:
+            if line.startswith('Measurements'):
+                meas_start_index = results.index(line) + 1
+            elif meas_start_index and '=' in line:
+                meas_end_index = results.index(line)
+        if meas_end_index:
+            for line in results[meas_start_index:meas_end_index]:
+                # Extract each measurement result as a k,v pair
+                print(line)
 
         # time.sleep(.1) # required before to test if the simulation is running
         # while (self._ngspice_shared.ngSpice_running()):

--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -285,7 +285,7 @@ class Plot(dict):
         else:
             raise NotImplementedError("Unsupported plot name {}".format(self.plot_name))
         
-        analysis._measurements = measurements # Unsafe! TODO: use a proper setter
+        analysis.measurements = measurements
         return analysis
 
     ##############################################
@@ -1213,7 +1213,7 @@ class NgSpiceShared:
             for line in results[meas_start_index:meas_end_index]:
                 # Extract each measurement result as a k,v pair
                 [k, _, v, *_] = line.split()
-                measurements[k] = v
+                measurements[k] = float(v)
         return measurements
 
         # time.sleep(.1) # required before to test if the simulation is running

--- a/PySpice/Spice/NgSpice/Simulation.py
+++ b/PySpice/Spice/NgSpice/Simulation.py
@@ -116,7 +116,7 @@ class NgSpiceSharedCircuitSimulator(NgSpiceCircuitSimulator):
         # load circuit and simulation
         # Fixme: Error: circuit not parsed.
         self._ngspice_shared.load_circuit(str(self))
-        self._ngspice_shared.run()
+        measurements = self._ngspice_shared.run()
         self._logger.debug(str(self._ngspice_shared.plot_names))
         self.reset_analysis()
 
@@ -124,4 +124,4 @@ class NgSpiceSharedCircuitSimulator(NgSpiceCircuitSimulator):
         if plot_name == 'const':
             raise NameError('Simulation failed')
 
-        return self._ngspice_shared.plot(self, plot_name).to_analysis()
+        return self._ngspice_shared.plot(self, plot_name).to_analysis(measurements)


### PR DESCRIPTION
Related to #346 

This PR allows PySpice to parse .measure results out of ngspice `run` output and attach them to Analysis objects when using the `ngspice-shared` simulation backend.

The code changes should be fairly straightforward - just fetch the results of a `.meas` directive from the response to ngspice `run` control directives, then pass the measurements up to the Analysis object. 