### PR TITLE
[fix Parser.py] fixed up the class Parser can not parser subckt by a mistake,

### DIFF
--- a/PySpice/Spice/Parser.py
+++ b/PySpice/Spice/Parser.py
@@ -1005,7 +1005,7 @@ class SpiceParser:
                 statement.build(circuit, ground)
             elif isinstance(statement, Model):
                 statement.build(circuit)
-            elif isinstance(statement, SubCircuit):
+            elif isinstance(statement, SubCircuitStatement):
                 subcircuit = statement.build(ground) # Fixme: ok ???
                 circuit.subcircuit(subcircuit)
 


### PR DESCRIPTION
That mistakely use isinstance to compare 'SubCircuitStatement' and 'SubCircuit',SubCircuitStatement is a new class in Parser.py to save the parsered statment begin with ".subckt" and end with ".ends".But "SubCircuit" is a class in Netlist.py.SO, WHEN WE TRY TO build_circuit by parser with a member "statement" the SubCircuitStatement is always skiped by mistake. I just fixed it. Just fixed a word in code, please merge it.

To make it easier to merge your pull request, you should divide your PR into smaller and easier-to-verify units.

Please do not make a pull requests with a lot of modifications which are difficult to check.  If I merge
pull requests blindly then there is a high risk this software will become a mess quickly for everybody.
