### PR TITLE
Fix issues when trying to use pyspice on windows

### DIFF
--- a/PySpice/Scripts/pyspice_post_installation.py
+++ b/PySpice/Scripts/pyspice_post_installation.py
@@ -31,6 +31,7 @@ import os
 import shutil
 import sys
 import tempfile
+import re
 
 import requests
 
@@ -252,8 +253,10 @@ class PySpicePostInstallation:
         print(rule)
         print(content)
         print(rule)
-        cm_path = spice64_path.joinpath('lib', 'ngspice')
-        content = content.replace('../lib/ngspice/', str(cm_path) + '/')
+        content = re.sub(r'^(\s*codemodel\s*).*[\\\/](.*)$',
+                         lambda x: "{} '{}'".format(x.group(1), spice64_path.joinpath('lib', 'ngspice', x.group(2))),
+                         content,
+                         flags=re.MULTILINE)
         print(rule)
         print(content)
         print(rule)

--- a/PySpice/Spice/Netlist.py
+++ b/PySpice/Spice/Netlist.py
@@ -1236,7 +1236,7 @@ class Circuit(Netlist):
                         path = path_flavour
                 real_paths.append(path)
 
-            return join_lines(real_paths, prefix='.include ') + os.linesep
+            return join_lines([f"'{p}'" for p in real_paths], prefix='.include ') + os.linesep
         else:
             return ''
 

--- a/PySpice/Spice/Parser.py
+++ b/PySpice/Spice/Parser.py
@@ -498,7 +498,7 @@ class Element(Statement):
                 i = parameter.position
                 self._dict_parameters[parameter.attribute_name] = self._parameters[i]
                 to_delete.append(i)
-        for i in to_delete:
+        for i in sorted(to_delete, reverse=True):
             del self._parameters[i]
 
         # self._logger.debug(os.linesep + self.__repr__())
@@ -890,7 +890,7 @@ class SpiceParser:
         # first line so they'll parse incorrectly if that line is removed.
         # For everything else, assume the first line is a TITLE line and
         # remove it.
-        if str(lines[0]).startswith(('.model', '.subckt')):
+        if str(lines[0]).lower().startswith(('.model', '.subckt')):
             start_index = 0
         else:
             start_index = 1


### PR DESCRIPTION
This will fix multiples issues:
On windows, the path may contains spaces:
- Fix post installation script in order to put quote arround paths 
- When rendering includes put quote arround paths

When parsing netlist:
- Delete params in reverse order
- case-insensitive matching for .model and .subckt