### PR TITLE
Fix: Incorrectly handles stderr outputs that aren't errors from libngspice version 43

### DIFF
--- a/PySpice/Spice/NgSpice/Shared.py
+++ b/PySpice/Spice/NgSpice/Shared.py
@@ -620,7 +620,8 @@ class NgSpiceShared:
             self._stderr.append(content)
             if content.startswith('Warning:'):
                 func = self._logger.warning
-            # elif content.startswith('Warning:'):
+            elif content.startswith('Using'): # Ignore "Using ... as Direct Linear Solver" messages
+                func = self._logger.debug 
             else:
                 self._error_in_stderr = True
                 func = self._logger.error


### PR DESCRIPTION
**Fixes #379**

This pull request addresses an issue where PySpice incorrectly handles certain stderr outputs from libngspice version 43, specifically messages like "Using SPARSE 1.3 as Direct Linear Solver". These messages, while appearing on stderr, are informational and not indicative of errors.

**Changes:**

- Modified the `_send_char` callback in `Spice/NgSpice/Shared.py` to specifically handle messages starting with "Using".
- These messages are now treated as debug output instead of errors, preventing the `self._error_in_stderr` flag from being set and avoiding the `NgSpiceCommandError`.
