### PR TITLE
Fix: Correct parameter unpacking in DeviceModel.clone to resolve TypeError

### DIFF
--- a/PySpice/Spice/Netlist.py
+++ b/PySpice/Spice/Netlist.py
@@ -162,7 +162,7 @@ class DeviceModel:
 
     def clone(self):
         # Fixme: clone parameters ???
-        return self.__class__(self._name, self._model_type, self._parameters)
+        return self.__class__(self._name, self._model_type, **self._parameters)
 
     ##############################################
 


### PR DESCRIPTION
### Problem
Cloning a `DeviceModel` instance was causing a `TypeError` due to incorrect handling of `self._parameters`. The `DeviceModel.clone` method passed `self._parameters` as a single positional argument instead of unpacking it as keyword arguments.

### Solution
- Updated the `DeviceModel.clone` method to unpack `self._parameters` using `**self._parameters`.
- Verified compatibility with `DeviceModel.__init__`, which expects `**parameters` as input.
- Ensured that `Netlist.copy_to` correctly uses the updated `clone` method to avoid errors during circuit cloning.

### Related Error
```plaintext
TypeError: DeviceModel.__init__() takes 3 positional arguments but 4 were given
Traceback (most recent call last):
  File "c:\Users\김정남\Documents\GitHub\PySpiceBasedModeling\Spice_AC_TEST.py", line 200, in <module>
    test.AC_TEST(SimType.IDVG)
  File "c:\Users\김정남\Documents\GitHub\PySpiceBasedModeling\Spice_AC_TEST.py", line 145, in AC_TEST
    test_circuit = self.circuit.clone()
                   ^^^^^^^^^^^^^^^^^^^^
  File "C:\Miniconda3\envs\pySpice\Lib\site-packages\PySpice\Spice\Netlist.py", line 1172, in clone
    self.copy_to(circuit)
  File "C:\Miniconda3\envs\pySpice\Lib\site-packages\PySpice\Spice\Netlist.py", line 842, in copy_to
    netlist._models[name] = model.clone()
                            ^^^^^^^^^^^^^
  File "C:\Miniconda3\envs\pySpice\Lib\site-packages\PySpice\Spice\Netlist.py", line 165, in clone
    return self.__class__(self._name, self._model_type, self._parameters)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: DeviceModel.__init__() takes 3 positional arguments but 4 were given
```

#### **Steps to Test**
Provide a quick guide for reviewers to test the fix:
```markdown
### Steps to Test
1. Create a `Circuit` instance and add a `DeviceModel` using `circuit.model()`.
2. Clone the circuit using `circuit.clone()`.
3. Verify that the cloned circuit is correctly created without raising any errors.
4. Confirm that all models, elements, and parameters are accurately copied to the cloned circuit.
```