### PR TITLE
Fix matplotlib 3.8+ log scale compatibility

### DIFF
--- a/PySpice/Plot/BodeDiagram.py
+++ b/PySpice/Plot/BodeDiagram.py
@@ -33,7 +33,10 @@ from matplotlib import pyplot
 
 def bode_diagram_gain(axe, frequency, gain, **kwargs):
 
-    axe.semilogx(frequency, gain, basex=10, **kwargs)
+    try:
+        axe.semilogx(frequency, gain, base=10, **kwargs)
+    except TypeError:
+        axe.semilogx(frequency, gain, basex=10, **kwargs)
     axe.grid(True)
     axe.grid(True, which='minor')
     axe.set_xlabel("Frequency [Hz]")
@@ -43,7 +46,10 @@ def bode_diagram_gain(axe, frequency, gain, **kwargs):
 
 def bode_diagram_phase(axe, frequency, phase, **kwargs):
 
-    axe.semilogx(frequency, phase, basex=10, **kwargs)
+    try:
+        axe.semilogx(frequency, phase, base=10, **kwargs)
+    except TypeError:
+        axe.semilogx(frequency, phase, basex=10, **kwargs)
     axe.set_ylim(-math.pi, math.pi)
     axe.grid(True)
     axe.grid(True, which='minor')


### PR DESCRIPTION
### Problem
Matplotlib >= 3.8 removed basex/basey parameters, causing PySpice plotting
to crash with TypeError.

### Solution
Add backward-compatible handling to support both old and new Matplotlib
APIs.

### Tested
- Python 3.10
- matplotlib 3.7.5
- matplotlib 3.8.2